### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete string escaping or encoding

### DIFF
--- a/js/es6/mediaviewer-tools.js
+++ b/js/es6/mediaviewer-tools.js
@@ -441,7 +441,7 @@ export const finalizeURL = () => {
             let currentURL = new URL(window.location.href);
             const requiredPattern = new RegExp(`${window.location.origin}${window.location.pathname}\\?.*`); // Adjust the pattern as needed
             if (!requiredPattern.test(currentURL.href)) {
-                currentURL = new URL(window.location.href.replace('&', '?'));
+                currentURL = new URL(window.location.href.replace(/&/g, '?'));
                 const params = new URLSearchParams(currentURL.search);
                 console.log(currentURL);
                 params.set('a', params.get('a'));


### PR DESCRIPTION
Potential fix for [https://github.com/XHiddenProjects/MediaViewer/security/code-scanning/1](https://github.com/XHiddenProjects/MediaViewer/security/code-scanning/1)

To fix the issue, we need to ensure that all occurrences of `&` in the `window.location.href` are replaced with `?`. This can be achieved by using a regular expression with the global (`g`) flag instead of a string as the first argument to the `replace` method. Regular expressions with the `g` flag ensure that all matches in the string are replaced, not just the first one.

The specific change involves replacing the line:
```js
currentURL = new URL(window.location.href.replace('&', '?'));
```
with:
```js
currentURL = new URL(window.location.href.replace(/&/g, '?'));
```

This ensures that all `&` characters in the URL are replaced with `?`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
